### PR TITLE
add 'wheel' in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+wheel
 pycrypto==2.6.1


### PR DESCRIPTION
When working with a new python environment, 'wheel' is not necessarily installed, and thus installation of `pip install -r requirements.txt` may complain.

So adding `wheel` in `requirements.txt` for completeness.