### PR TITLE
Prevent issues with newlines in keys and add Azure credentials plugin

### DIFF
--- a/decrypt.py
+++ b/decrypt.py
@@ -24,13 +24,13 @@ class JenkinsDecrypt():
 
     def load_master_key(self, master_key):
         """Read master.key which is used to decrypt instances of ConfidentialKey"""
-        master_key = open(master_key, "rb").read()
+        master_key = open(master_key, "rb").read().strip()
         self.hashed_master_key = sha256(master_key).digest()[:16]
 
 
     def load_credentials_confidential_key(self, path, key_name):
         """Read and decrypt an instance of ConfidentialKey"""
-        secret_key_file = open(path, "rb").read()
+        secret_key_file = open(path, "rb").read().strip()
         o = AES.new(self.hashed_master_key, AES.MODE_ECB)
         secret = o.decrypt(secret_key_file)
 

--- a/decrypt.py
+++ b/decrypt.py
@@ -215,7 +215,9 @@ class JenkinsDecrypt():
             "org.jenkinsci.plugins.kubernetes.credentials.OpenShiftBearerTokenCredentialImpl",
             "org.jenkinsci.plugins.p4.credentials.P4PasswordImpl",
             "org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl",
-            "org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl"
+            "org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl",
+
+            "com.microsoft.azure.util.AzureCredentials"
         ]
 
         # Find, decrypt, and print credentials for each plugin
@@ -305,6 +307,15 @@ class JenkinsDecrypt():
                     elif plugin == "org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl":
                         output = "Secret string: {}".format(
                             self.decrypt(cred.get("secret", None)))
+                        output = self.add_attributes(output, cred, description="Description")
+
+                    # Azure creds
+                    elif plugin == "com.microsoft.azure.util.AzureCredentials":
+                        output = "subscriptionId: {}\nclientId: {}\nclientSecret: {}\ntenant: {}".format(
+                            self.decrypt(cred.get("subscriptionId", None)),
+                            self.decrypt(cred.get("clientId", None)),
+                            self.decrypt(cred.get("clientSecret", None)),
+                            self.decrypt(cred.get("tenant", None)))
                         output = self.add_attributes(output, cred, description="Description")
 
                     # Only print plugin info if we find results


### PR DESCRIPTION
I've had an issue with the keys not being computed correctly because of a newline in a file. After some debug and thanks to  https://github.com/gquere/pwn_jenkins/blob/3b577627d80b22d12eba8686e31ddb13932e6f9e/offline_decryption/jenkins_offline_decrypt.py#L39 I found out why :) It's fixed now.

I've also added support for Azure credentials (if our blue team reads me, yes, I needed this 😋)

